### PR TITLE
Add Jest tests for parking functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# HOA Parking
+
+## Testing
+
+1. Install dependencies (Jest and related packages):
+   ```bash
+   npm install
+   ```
+2. Run the test suite:
+   ```bash
+   npm test
+   ```
+
+The tests are located in the `__tests__` directory and cover parking record logic such as adding records and counting remaining spaces.

--- a/__tests__/records.test.js
+++ b/__tests__/records.test.js
@@ -1,0 +1,99 @@
+const {
+  addRecord,
+  recordCount,
+} = require('../public/scripts/records');
+
+beforeEach(() => {
+  // simple DOM setup
+  document.body.innerHTML = `
+    <input id="data-parking-pass-date" />
+    <input id="data-member-name" />
+    <input id="data-member-address" />
+    <input id="data-make" />
+    <input id="data-model" />
+    <input id="data-license-plate" />
+    <div id="tbl-records"><tbody></tbody></div>
+    <span id="recordcount"></span>
+  `;
+
+  global.$ = (selector) => {
+    const elements = Array.from(document.querySelectorAll(selector));
+    return {
+      val(value) {
+        if (value === undefined) return elements[0]?.value;
+        elements.forEach((el) => (el.value = value));
+        return this;
+      },
+      html(value) {
+        if (value === undefined) return elements[0]?.innerHTML;
+        elements.forEach((el) => (el.innerHTML = value));
+        return this;
+      },
+      append(value) {
+        elements.forEach((el) => el.insertAdjacentHTML('beforeend', value));
+        return this;
+      },
+      button() {
+        return this;
+      },
+      buttonMarkup() {
+        return this;
+      },
+      table() {
+        return this;
+      },
+      attr(name, value) {
+        if (value === undefined) return elements[0]?.getAttribute(name);
+        elements.forEach((el) => el.setAttribute(name, value));
+        return this;
+      },
+    };
+  };
+
+  global.getCurrentDateFormatted = () => '2021-01-01';
+  global.alert = jest.fn();
+  localStorage.clear();
+});
+
+describe('addRecord', () => {
+  test('returns true when a spot is available', () => {
+    document.getElementById('data-parking-pass-date').value = '2021-01-01';
+    document.getElementById('data-member-name').value = 'John';
+    document.getElementById('data-member-address').value = '123 St';
+    document.getElementById('data-make').value = 'Ford';
+    document.getElementById('data-model').value = 'Focus';
+    document.getElementById('data-license-plate').value = 'ABC123';
+
+    const result = addRecord();
+    expect(result).toBe(true);
+    const records = JSON.parse(localStorage.getItem('tbRecords'));
+    expect(records.length).toBe(1);
+  });
+
+  test('returns false when spots are full', () => {
+    const full = new Array(35).fill({ Date: '2021-01-01' });
+    localStorage.setItem('tbRecords', JSON.stringify(full));
+
+    document.getElementById('data-parking-pass-date').value = '2021-01-01';
+    document.getElementById('data-member-name').value = 'John';
+    document.getElementById('data-member-address').value = '123 St';
+    document.getElementById('data-make').value = 'Ford';
+    document.getElementById('data-model').value = 'Focus';
+    document.getElementById('data-license-plate').value = 'ABC123';
+
+    const result = addRecord();
+    expect(result).toBe(false);
+    const records = JSON.parse(localStorage.getItem('tbRecords'));
+    expect(records.length).toBe(35);
+  });
+});
+
+describe('recordCount', () => {
+  test('updates DOM with remaining spots', () => {
+    const records = new Array(5).fill({ Date: '2021-01-01' });
+    localStorage.setItem('tbRecords', JSON.stringify(records));
+    const remaining = recordCount();
+    expect(remaining).toBe(30);
+    expect(document.getElementById('recordcount').innerHTML).toBe('30');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -2,5 +2,13 @@
   "dependencies": {
     "firebase": "^9.3.0",
     "firebaseui": "^6.0.0"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "jest-localstorage-mock": "^2.4.18"
+  },
+  "scripts": {
+    "test": "jest"
   }
 }

--- a/public/scripts/records.js
+++ b/public/scripts/records.js
@@ -141,12 +141,13 @@ function addRecord() {
         alert("Saving Information");
         clearRecordForm();
         listRecords();
-      } else
+        return true;
+      } else {
         alert(
           "Guest Parking Spots are full for today. We apologize for the inconvenience."
         );
-
-      return true;
+        return false;
+      }
     } catch (e) {
       if (window.navigator.vendor === "Google Inc.") {
         if (e === DOMException.QUOTA_EXCEEDED_ERR) {
@@ -410,4 +411,21 @@ function recordCount() {
   document.getElementById("recordcount").innerHTML = remainingSpots;
 
   return remainingSpots;
+}
+
+if (typeof module !== "undefined") {
+  module.exports = {
+    addRecord,
+    recordCount,
+    clearRecordForm,
+    listRecords,
+    checkRecordForm,
+    compareDates,
+    deleteRecord,
+    editRecord,
+    callEdit,
+    callDelete,
+    loadUserInformation,
+    showRecordForm,
+  };
 }


### PR DESCRIPTION
## Summary
- set up Jest and testing script
- export helper functions from `records.js`
- fix `addRecord` return value when lot is full
- add unit tests for record logic
- document how to run the tests

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880ec88d074832da0b97bb2ec9775c9